### PR TITLE
Add `--template`

### DIFF
--- a/helpro/molpro/inp.py
+++ b/helpro/molpro/inp.py
@@ -276,6 +276,17 @@ class MolproInputGeometry:
         return "\n".join(lines)
 
 
+def _make_default_template() -> tuple[str]:
+    lines = (
+        r"GPRINT,ORBITALS",
+        r"NOSYM",
+        r"{{geometry}}",
+        r"BASIS={{basis}}",
+        r"{{method}}",
+    )
+    return tuple(f"{_}\n" for _ in lines)
+
+
 @dataclass(slots=True)
 class MolproInputWriter:
     """Writer of MOLPRO input file.
@@ -312,11 +323,19 @@ class MolproInputWriter:
     charge: int | None = None
     multiplicity: int | None = None
     options: list[str] | str | None = None
+    template: tuple[str] = field(default_factory=_make_default_template)
 
     def __post_init__(self) -> None:
         """Post-process attributes."""
         if isinstance(self.geometry, str):
             self.geometry = MolproInputGeometry(self.geometry)
+        if isinstance(self.template, Path | str):
+            if isinstance(self.template, str):
+                path = Path(self.template)
+            else:
+                path = self.template
+            with path.open(encoding="utf-8") as fd:
+                self.template = tuple(fd.readlines())
 
     def write(self, fname: str | None = None) -> None:
         """Write MOLPRO input file.
@@ -343,15 +362,6 @@ class MolproInputWriter:
 
         self.options = validate_options(self.options)
 
-        lines = (
-            r"GPRINT,ORBITALS",
-            r"NOSYM",
-            self.geometry.make_lines(),
-            r"BASIS=__basis__",
-            r"__method__",
-        )
-        lines = tuple(f"{_}\n" for _ in lines)
-
         basis_lines = make_basis_lines(
             self.method,
             parse_heavy_basis(self.basis),
@@ -365,13 +375,19 @@ class MolproInputWriter:
             multiplicity=self.multiplicity,
         )
 
+        dct = {
+            r"{{geometry}}": self.geometry.make_lines(),
+            r"{{basis}}": basis_lines,
+            r"{{method}}": method_lines,
+        }
+
         p = Path(fname)
         with p.open("w", encoding="utf-8") as f:
-            for line in lines:
-                if "__basis__" in line:
-                    f.write(line.replace("__basis__", basis_lines))
-                elif "__method__" in line:
-                    f.write(line.replace("__method__", method_lines))
+            for line in self.template:
+                for k, v in dct.items():
+                    if k in line:
+                        f.write(line.replace(k, v))
+                        break
                 else:
                     f.write(line)
             for option in self.options:
@@ -388,6 +404,7 @@ def add_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--geometry", default="initial.xyz")
     parser.add_argument("--charge", type=int)
     parser.add_argument("--multiplicity", type=int)
+    parser.add_argument("-t", "--template", help="Template filename")
 
 
 def run(args: argparse.Namespace) -> None:
@@ -404,5 +421,6 @@ def run(args: argparse.Namespace) -> None:
         geometry=args.geometry,
         charge=args.charge,
         multiplicity=args.multiplicity,
+        template=args.template,
     )
     miw.write("molpro.inp")

--- a/helpro/molpro/inp.py
+++ b/helpro/molpro/inp.py
@@ -197,10 +197,11 @@ def make_basis_lines(method: str, basis: str) -> list[str]:
         Commnd for the basis set.
 
     """
+    basis = parse_heavy_basis(basis)
     props = methods_all[method]
     if props.is_ksrpa:
         lines = (
-            r"{",
+            r"BASIS={",
             r"SET,ORBITAL",
             f"DEFAULT={basis}",
             r"SET,MP2FIT",
@@ -210,7 +211,7 @@ def make_basis_lines(method: str, basis: str) -> list[str]:
         return "\n".join(lines)
     if props.is_acfd:
         lines = (
-            r"{",
+            r"BASIS={",
             r"SET,ORBITAL",
             f"DEFAULT={basis}",
             r"SET,RI,CONTEXT=MP2FIT",
@@ -218,7 +219,7 @@ def make_basis_lines(method: str, basis: str) -> list[str]:
             r"}",
         )
         return "\n".join(lines)
-    return basis
+    return f"BASIS={basis}"
 
 
 def validate_options(options: str | list[str] | None) -> list[str]:
@@ -281,7 +282,7 @@ def _make_default_template() -> tuple[str]:
         r"GPRINT,ORBITALS",
         r"NOSYM",
         r"{{geometry}}",
-        r"BASIS={{basis}}",
+        r"{{basis}}",
         r"{{method}}",
     )
     return tuple(f"{_}\n" for _ in lines)
@@ -362,10 +363,7 @@ class MolproInputWriter:
 
         self.options = validate_options(self.options)
 
-        basis_lines = make_basis_lines(
-            self.method,
-            parse_heavy_basis(self.basis),
-        )
+        basis_lines = make_basis_lines(self.method, self.basis)
 
         method_lines = make_method_lines(
             self.method,

--- a/tests/molpro/inp/test_inp.py
+++ b/tests/molpro/inp/test_inp.py
@@ -137,7 +137,7 @@ def test_template(tmp_path: Path) -> None:
         r"GCOSMO,epsilon=78.3553",
         r"NOSYM",
         r"{{geometry}}",
-        r"BASIS={{basis}}",
+        r"{{basis}}",
         r"{{method}}",
     )
     path_tpl = tmp_path / "molpro.inp.j2"

--- a/tests/molpro/inp/test_inp.py
+++ b/tests/molpro/inp/test_inp.py
@@ -128,3 +128,36 @@ def test_options(tmp_path: Path) -> None:
         s = f.read()
 
     assert s == sref
+
+
+def test_template(tmp_path: Path) -> None:
+    """Test if `template` can be provided."""
+    tpl = (
+        r"GPRINT,ORBITALS",
+        r"GCOSMO,epsilon=78.3553",
+        r"NOSYM",
+        r"{{geometry}}",
+        r"BASIS={{basis}}",
+        r"{{method}}",
+    )
+    path_tpl = tmp_path / "molpro.inp.j2"
+    with path_tpl.open("w", encoding="utf-8") as fd:
+        fd.writelines("".join(f"{_}\n" for _ in tpl))
+
+    sref = (
+        r"GPRINT,ORBITALS",
+        r"GCOSMO,epsilon=78.3553",
+        r"NOSYM",
+        r"ANGSTROM",
+        r"GEOMETRY=initial.xyz",
+        r"BASIS=cc-pVDZ",
+        r"{HF}",
+    )
+    sref = "".join(f"{_}\n" for _ in sref)
+
+    miw = MolproInputWriter(method="HF", basis="cc-pVDZ", template=path_tpl)
+    path = tmp_path / "molpro.inp"
+    miw.write(fname=path)
+    with path.open("r", encoding="utf-8") as f:
+        s = f.read()
+    assert s == sref


### PR DESCRIPTION
This PR adds the `--template` option. This allows us to make `molpro.inp` more flexibly.